### PR TITLE
Improve README.md and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
+all: dependencies build
+
 build:
-	go build -o morse led.go morse.go 
+	go build -o morse led.go morse.go
+
 dependencies:
 	go get github.com/pebbe/zmq4
 	go get github.com/matrix-io/matrix-protos-go/matrix_io/malos/v1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # matrix_creator_morse
 
-This project uses the MATRIX Creator to display Morse code with its Everloop LEDs from a given string. It is used in conjunction with a web server to display the IP address of a connected client in the physical world.
+This project uses the [MATRIX Creator](https://www.matrix.one/products/creator) to display Morse code with its Everloop LEDs from a given string. It is used in conjunction with a web server to display the IP address of a connected client in the physical world.
 
 To get started, first run the following:
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,24 @@
 # matrix_creator_morse
-Project to use the MATRIX Creator to display morse code with the Everloop LEDs from a given string. Used in conjunction with a web server to display the IP address of a connected client in the physical world.
 
-After cloning repo run:
+This project uses the MATRIX Creator to display Morse code with its Everloop LEDs from a given string. It is used in conjunction with a web server to display the IP address of a connected client in the physical world.
 
+To get started, first run the following:
+
+```sh
+git clone https://github.com/alexfarra/matrix_creator_morse.git
+make
 ```
-make dependencies && make
-```
 
-To use:
+To use, run:
 
-```
+```sh
 ./morse <IPv4 address>
 ```
 
 For example:
 
-```
+```sh
 ./morse 192.168.2.2
 ```
 
-will make the device light up in RGBW colors corresponding to each section of the IP address. You can think of an IP address as RRR.GGG.BBB.WWW and the LEDs will blink the IP back in morse code.
+This will make the device light up with RGBW colors corresponding to each section of the IP address (i.e. `RRR.GGG.BBB.WWW`). The LEDs will also blink the IP address back as Morse code.


### PR DESCRIPTION
Now only needs `make` or `make all` to build everything.

Phrasing in README.md has been adjusted slightly and also reflects the change in the Makefile.